### PR TITLE
[ENH] Add cluster-contribution tables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,140 @@
+.DS_Store
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/code/ale.py
+++ b/code/ale.py
@@ -9,6 +9,7 @@ from nimare.correct import FWECorrector
 from nimare.meta.ale import ALE, ALESubtraction
 
 def thresh_img(logp_img, z_img, p):
+    # Natural log was used until NiMARE 0.0.4, and this manuscript used 0.0.3.
     sig_inds = np.where(logp_img.get_fdata() > -np.log(p))
     z_img_data = z_img.get_fdata()
     z_img_thresh_data = np.zeros(z_img.shape)

--- a/code/summarize_clusters.py
+++ b/code/summarize_clusters.py
@@ -1,0 +1,133 @@
+"""Create summary tables of the ALE meta-analyses."""
+import os.path as op
+from glob import glob
+
+import nibabel as nib
+import numpy as np
+import pandas as pd
+from nilearn import masking
+from nimare import utils
+from nimare.io import convert_sleuth_to_dataset
+from nimare.meta.kernel import ALEKernel
+from scipy import ndimage
+from scipy.spatial.distance import cdist
+
+
+def summarize_image(dset, img):
+    img = nib.load(img)
+    ale_kernel = ALEKernel()
+    ma_imgs = ale_kernel.transform(dset, return_type="image")
+
+    # Define array for 6-connectivity, aka NN1 or "faces"
+    conn_mat = np.zeros((3, 3, 3), int)
+    conn_mat[1, 1, :] = 1
+    conn_mat[1, :, 1] = 1
+    conn_mat[:, 1, 1] = 1
+
+    stat_map = img.get_fdata()
+
+    # Binarize using CDT
+    binarized = stat_map > 1.64
+    binarized = binarized.astype(int)
+
+    # Now re-label and create table
+    label_map = ndimage.measurements.label(binarized, conn_mat)[0]
+    clust_ids = sorted(list(np.unique(label_map)[1:]))
+
+    df = pd.DataFrame(index=dset.ids, columns=clust_ids)
+    gingerale_df = pd.DataFrame(index=dset.ids, columns=clust_ids)
+
+    for i_cluster, c_val in enumerate(clust_ids):
+        cluster_mask = label_map == c_val
+        cluster_idx = np.vstack(np.where(cluster_mask))
+
+        cluster_mask = nib.Nifti1Image(
+            cluster_mask.astype(int), img.affine, header=img.header
+        )
+        ma_data = masking.apply_mask(ma_imgs, cluster_mask)
+        ma_summary = np.sum(ma_data, axis=1)
+        ma_summary /= np.sum(ma_summary)
+        df[c_val] = ma_summary
+
+        for j_exp, exp_id in enumerate(dset.ids):
+            coords = dset.coordinates.loc[dset.coordinates["id"] == exp_id]
+            ijk = utils.mm2vox(coords[["x", "y", "z"]], img.affine)
+            distances = cdist(cluster_idx.T, ijk)
+            distances = distances < 1
+            distances = np.any(distances, axis=0)
+            n_included_voxels = np.sum(distances)
+            gingerale_df.loc[exp_id, c_val] = n_included_voxels
+
+    return df, gingerale_df
+
+
+if __name__ == "__main__":
+    project_dir = op.abspath("..")
+    input_dir = op.join(project_dir, "derivatives/ale")
+    output_dir = op.join(project_dir, "derivatives/ale-tables")
+
+    # Combined meta-analysis
+    # Import all the text files to create a combined text file dataset
+    # All
+    text_files = glob(op.join(project_dir, "code/text-files/*.txt"))
+    dset = convert_sleuth_to_dataset(text_files, target="mni152_2mm")
+    img_file = op.join(
+        input_dir,
+        "TrauEgtPTSD+HCgtPTSD_z_level-cluster_corr-FWE_method-montecarlo.nii.gz",
+    )
+    df, df_ga = summarize_image(dset, img_file)
+    print(dset)
+    df.to_csv(
+        op.join(output_dir, "TrauEgtPTSD+HCgtPTSD_taylor.tsv"),
+        sep="\t",
+        index=True,
+        index_label="Experiment",
+    )
+    df_ga.to_csv(
+        op.join(output_dir, "TrauEgtPTSD+HCgtPTSD_gingerale.tsv"),
+        sep="\t",
+        index=True,
+        index_label="Experiment",
+    )
+
+    # TrauEgtPTSD
+    text_files = glob(op.join(project_dir, "code/text-files/*TrauEgtPTSD*.txt"))
+    dset = convert_sleuth_to_dataset(text_files, target="mni152_2mm")
+    img_file = op.join(
+        input_dir, "TrauEgtPTSD_z_level-cluster_corr-FWE_method-montecarlo.nii.gz"
+    )
+    df, df_ga = summarize_image(dset, img_file)
+    print(dset)
+    df.to_csv(
+        op.join(output_dir, "TrauEgtPTSD_taylor.tsv"),
+        sep="\t",
+        index=True,
+        index_label="Experiment",
+    )
+    df_ga.to_csv(
+        op.join(output_dir, "TrauEgtPTSD_gingerale.tsv"),
+        sep="\t",
+        index=True,
+        index_label="Experiment",
+    )
+
+    # HCgtPTSD
+    text_files = glob(op.join(project_dir, "code/text-files/*HCgtPTSD*.txt"))
+    dset = convert_sleuth_to_dataset(text_files, target="mni152_2mm")
+    img_file = op.join(
+        input_dir, "HCgtPTSD_z_level-cluster_corr-FWE_method-montecarlo.nii.gz"
+    )
+    df, df_ga = summarize_image(dset, img_file)
+    print(dset)
+    df.to_csv(
+        op.join(output_dir, "HCgtPTSD_taylor.tsv"),
+        sep="\t",
+        index=True,
+        index_label="Experiment",
+    )
+    df_ga.to_csv(
+        op.join(output_dir, "HCgtPTSD_gingerale.tsv"),
+        sep="\t",
+        index=True,
+        index_label="Experiment",
+    )

--- a/derivatives/ale-tables/HCgtPTSD_gingerale.tsv
+++ b/derivatives/ale-tables/HCgtPTSD_gingerale.tsv
@@ -1,0 +1,10 @@
+Experiment
+Bossini et al., 2017; HCs > PTSD-
+Chen et al., 2012; HCs > PTSD-
+Cheng et al., 2015; HCs > PTSD-
+Corbo et al., 2005; HCs > PTSD-
+Eckart et al., 2011; HCs > PTSD-
+Hakamata et al., 2007; HCs > PTSD-
+O'Dohetry et al., 2017; HCs > PTSD-
+Sui et al., 2010; HCs > PTSD-
+Tavanti et al., 2012; HCs > PTSD-

--- a/derivatives/ale-tables/HCgtPTSD_taylor.tsv
+++ b/derivatives/ale-tables/HCgtPTSD_taylor.tsv
@@ -1,0 +1,10 @@
+Experiment
+Bossini et al., 2017; HCs > PTSD-
+Chen et al., 2012; HCs > PTSD-
+Cheng et al., 2015; HCs > PTSD-
+Corbo et al., 2005; HCs > PTSD-
+Eckart et al., 2011; HCs > PTSD-
+Hakamata et al., 2007; HCs > PTSD-
+O'Dohetry et al., 2017; HCs > PTSD-
+Sui et al., 2010; HCs > PTSD-
+Tavanti et al., 2012; HCs > PTSD-

--- a/derivatives/ale-tables/TrauEgtPTSD+HCgtPTSD_gingerale.tsv
+++ b/derivatives/ale-tables/TrauEgtPTSD+HCgtPTSD_gingerale.tsv
@@ -1,0 +1,26 @@
+Experiment	1
+Bossini et al., 2017; HCs > PTSD-	0
+Chao et al., 2012; TrauE > PTSD-	0
+Chen et al., 2009; TrauE > PTSD-	1
+Chen et al., 2012; HCs > PTSD-	0
+Cheng et al., 2015; HCs > PTSD-	0
+Corbo et al., 2005; HCs > PTSD-	0
+Eckart et al., 2011; HCs > PTSD-	0
+Flemingham et al., 2009; TrauE > PTSD-	2
+Hakamata et al., 2007; HCs > PTSD-	0
+Hakamata et al., 2007; TrauE > PTSD-	0
+Herringa et al., 2012; TrauE > PTSD-	0
+Kasi et al., 2008; TrauE > PTSD-	1
+Kroes et al., 2011; TrauE > PTSD-	1
+Li et al., 2006; TrauE > PTSD-	1
+Nardo et al., 2010; TrauE > PTSD-	0
+O'Dohetry et al., 2017; HCs > PTSD-	2
+O'Dohetry et al., 2017; TrauE > PTSD-	1
+Qi et al., 2020; TrauE > PTSD-	1
+Rocha-Rego et al., 2012; TrauE > PTSD-	0
+Sui et al., 2010; HCs > PTSD-	0
+Sui et al., 2010; TrauE > PTSD-	0
+Tavanti et al., 2012; HCs > PTSD-	0
+Yamasue et al., 2003; TrauE > PTSD-	0
+Zhang et al., 2011; TrauE > PTSD-	0
+Zhang et al., 2018; TrauE > PTSD-	0

--- a/derivatives/ale-tables/TrauEgtPTSD+HCgtPTSD_taylor.tsv
+++ b/derivatives/ale-tables/TrauEgtPTSD+HCgtPTSD_taylor.tsv
@@ -1,0 +1,26 @@
+Experiment	1
+Bossini et al., 2017; HCs > PTSD-	0.0
+Chao et al., 2012; TrauE > PTSD-	0.0
+Chen et al., 2009; TrauE > PTSD-	0.07754246931602932
+Chen et al., 2012; HCs > PTSD-	1.8111361554289107e-06
+Cheng et al., 2015; HCs > PTSD-	0.0
+Corbo et al., 2005; HCs > PTSD-	0.00048550427458144183
+Eckart et al., 2011; HCs > PTSD-	0.003726868250226739
+Flemingham et al., 2009; TrauE > PTSD-	0.17726732120885016
+Hakamata et al., 2007; HCs > PTSD-	0.0
+Hakamata et al., 2007; TrauE > PTSD-	0.0
+Herringa et al., 2012; TrauE > PTSD-	0.0
+Kasi et al., 2008; TrauE > PTSD-	0.127297447922204
+Kroes et al., 2011; TrauE > PTSD-	0.10260130547992467
+Li et al., 2006; TrauE > PTSD-	0.10811390636062501
+Nardo et al., 2010; TrauE > PTSD-	0.0
+O'Dohetry et al., 2017; HCs > PTSD-	0.17853811380041207
+O'Dohetry et al., 2017; TrauE > PTSD-	0.10818647555362784
+Qi et al., 2020; TrauE > PTSD-	0.08763123902495257
+Rocha-Rego et al., 2012; TrauE > PTSD-	0.026660997228575428
+Sui et al., 2010; HCs > PTSD-	0.0018493397739574257
+Sui et al., 2010; TrauE > PTSD-	0.0
+Tavanti et al., 2012; HCs > PTSD-	9.720066987785821e-05
+Yamasue et al., 2003; TrauE > PTSD-	0.0
+Zhang et al., 2011; TrauE > PTSD-	0.0
+Zhang et al., 2018; TrauE > PTSD-	0.0

--- a/derivatives/ale-tables/TrauEgtPTSD_gingerale.tsv
+++ b/derivatives/ale-tables/TrauEgtPTSD_gingerale.tsv
@@ -1,0 +1,17 @@
+Experiment	1
+Chao et al., 2012; TrauE > PTSD-	0
+Chen et al., 2009; TrauE > PTSD-	1
+Flemingham et al., 2009; TrauE > PTSD-	2
+Hakamata et al., 2007; TrauE > PTSD-	0
+Herringa et al., 2012; TrauE > PTSD-	0
+Kasi et al., 2008; TrauE > PTSD-	1
+Kroes et al., 2011; TrauE > PTSD-	1
+Li et al., 2006; TrauE > PTSD-	1
+Nardo et al., 2010; TrauE > PTSD-	0
+O'Dohetry et al., 2017; TrauE > PTSD-	1
+Qi et al., 2020; TrauE > PTSD-	1
+Rocha-Rego et al., 2012; TrauE > PTSD-	1
+Sui et al., 2010; TrauE > PTSD-	0
+Yamasue et al., 2003; TrauE > PTSD-	0
+Zhang et al., 2011; TrauE > PTSD-	0
+Zhang et al., 2018; TrauE > PTSD-	0

--- a/derivatives/ale-tables/TrauEgtPTSD_taylor.tsv
+++ b/derivatives/ale-tables/TrauEgtPTSD_taylor.tsv
@@ -1,0 +1,17 @@
+Experiment	1
+Chao et al., 2012; TrauE > PTSD-	0.0
+Chen et al., 2009; TrauE > PTSD-	0.10296023159156768
+Flemingham et al., 2009; TrauE > PTSD-	0.1969078593600538
+Hakamata et al., 2007; TrauE > PTSD-	0.0
+Herringa et al., 2012; TrauE > PTSD-	0.0
+Kasi et al., 2008; TrauE > PTSD-	0.15725353307216286
+Kroes et al., 2011; TrauE > PTSD-	0.13733432701201428
+Li et al., 2006; TrauE > PTSD-	0.13591020482123403
+Nardo et al., 2010; TrauE > PTSD-	0.0
+O'Dohetry et al., 2017; TrauE > PTSD-	0.11149776632437684
+Qi et al., 2020; TrauE > PTSD-	0.11110554768459623
+Rocha-Rego et al., 2012; TrauE > PTSD-	0.047030530133994324
+Sui et al., 2010; TrauE > PTSD-	0.0
+Yamasue et al., 2003; TrauE > PTSD-	0.0
+Zhang et al., 2011; TrauE > PTSD-	0.0
+Zhang et al., 2018; TrauE > PTSD-	0.0


### PR DESCRIPTION
I've added a script (`summarize_clusters.py`) that creates tab-delimited files containing information about which studies in each ALE contributed to each of the significant clusters. There are two versions: `taylor` and `gingerale`. The `taylor` files have the proportion of summed MA values in each cluster that come from each experiment. The `gingerale` ones have the number of foci that fall within the cluster for each experiment.

Also I added necessary GitHub files, like the license, gitignore, and README.